### PR TITLE
Agent Manager Improvements and additional internal agents

### DIFF
--- a/ratio/agents/internal_api/delete_directory.agent
+++ b/ratio/agents/internal_api/delete_directory.agent
@@ -1,0 +1,95 @@
+{
+  "arguments": [
+    {
+      "name": "directory_path",
+      "type_name": "string",
+      "description": "The full path of the directory to delete",
+      "required": true
+    },
+    {
+      "name": "force",
+      "type_name": "boolean",
+      "description": "Force deletion even if the directory contains files with lineage",
+      "required": false,
+      "default_value": false
+    }
+  ],
+  "description": "A T2 agent that deletes a directory and all its contents by calling the storage manager's delete file API with recursive option",
+  "instructions": [
+    {
+      "agent_definition": {
+        "arguments": [
+          {
+            "name": "path",
+            "type_name": "string",
+            "description": "The API path for the request",
+            "required": true
+          },
+          {
+            "name": "fail_on_error",
+            "type_name": "bool",
+            "description": "Whether the agent run should fail in the case of an error",
+            "default_value": true,
+            "required": false
+          },
+          {
+            "name": "request",
+            "type_name": "object",
+            "description": "The API request object",
+            "required": true
+          },
+          {
+            "name": "target_service",
+            "type_name": "string",
+            "enum": ["PROCESS", "SCHEDULER", "STORAGE"],
+            "description": "The internal service to send the request to",
+            "required": true
+          }
+        ],
+        "responses": [
+          {
+            "name": "status_code",
+            "type_name": "number",
+            "description": "The responding status code from the API call",
+            "required": true
+          },
+          {
+            "name": "response_body",
+            "type_name": "object",
+            "description": "The response body from the API call",
+            "required": false
+          }
+        ],
+        "system_event_endpoint": "ratio::agent::internal_api::execution"
+      },
+      "arguments": {
+        "path": "/delete_file",
+        "target_service": "STORAGE",
+        "request": {
+          "file_path": "REF:arguments.directory_path",
+          "force": "REF:arguments.force",
+          "recursive": true
+        }
+      },
+      "execution_id": "delete_directory_request"
+    }
+  ],
+  "response_reference_map": {
+    "status_code": "REF:delete_directory_request.status_code",
+    "response_body": "REF:delete_directory_request.response_body"
+  },
+  "responses": [
+    {
+      "name": "status_code",
+      "type_name": "number",
+      "description": "The responding status code from the API call",
+      "required": true
+    },
+    {
+      "name": "response_body",
+      "type_name": "object",
+      "description": "The response body from the API call",
+      "required": false
+    }
+  ]
+}

--- a/ratio/agents/internal_api/delete_file.agent
+++ b/ratio/agents/internal_api/delete_file.agent
@@ -1,0 +1,95 @@
+{
+  "arguments": [
+    {
+      "name": "file_path",
+      "type_name": "string",
+      "description": "The full path of the file to delete",
+      "required": true
+    },
+    {
+      "name": "force",
+      "type_name": "boolean",
+      "description": "Force deletion even if the file is part of a lineage",
+      "required": false,
+      "default_value": false
+    }
+  ],
+  "description": "A T2 agent that deletes a file by calling the storage manager's delete file API",
+  "instructions": [
+    {
+      "agent_definition": {
+        "arguments": [
+          {
+            "name": "path",
+            "type_name": "string",
+            "description": "The API path for the request",
+            "required": true
+          },
+          {
+            "name": "fail_on_error",
+            "type_name": "bool",
+            "description": "Whether the agent run should fail in the case of an error",
+            "default_value": true,
+            "required": false
+          },
+          {
+            "name": "request",
+            "type_name": "object",
+            "description": "The API request object",
+            "required": true
+          },
+          {
+            "name": "target_service",
+            "type_name": "string",
+            "enum": ["PROCESS", "SCHEDULER", "STORAGE"],
+            "description": "The internal service to send the request to",
+            "required": true
+          }
+        ],
+        "responses": [
+          {
+            "name": "status_code",
+            "type_name": "number",
+            "description": "The responding status code from the API call",
+            "required": true
+          },
+          {
+            "name": "response_body",
+            "type_name": "object",
+            "description": "The response body from the API call",
+            "required": false
+          }
+        ],
+        "system_event_endpoint": "ratio::agent::internal_api::execution"
+      },
+      "arguments": {
+        "path": "/delete_file",
+        "target_service": "STORAGE",
+        "request": {
+          "file_path": "REF:arguments.file_path",
+          "force": "REF:arguments.force",
+          "recursive": false
+        }
+      },
+      "execution_id": "delete_file_request"
+    }
+  ],
+  "response_reference_map": {
+    "status_code": "REF:delete_file_request.status_code",
+    "response_body": "REF:delete_file_request.response_body"
+  },
+  "responses": [
+    {
+      "name": "status_code",
+      "type_name": "number",
+      "description": "The responding status code from the API call",
+      "required": true
+    },
+    {
+      "name": "response_body",
+      "type_name": "object",
+      "description": "The response body from the API call",
+      "required": false
+    }
+  ]
+}

--- a/ratio/agents/internal_api/describe_file_version.agent
+++ b/ratio/agents/internal_api/describe_file_version.agent
@@ -1,0 +1,241 @@
+{
+  "arguments": [
+    {
+      "name": "file_path",
+      "type_name": "string",
+      "description": "The full path of the file to describe the version for",
+      "required": true
+    },
+    {
+      "name": "version_id",
+      "type_name": "string",
+      "description": "The version ID to describe. If not provided, describes the latest version",
+      "required": false
+    },
+    {
+      "name": "include_lineage",
+      "type_name": "boolean",
+      "description": "Whether to include lineage information in the response",
+      "required": false,
+      "default_value": false
+    }
+  ],
+  "description": "A T2 agent that describes a specific version of a file by calling the storage manager's describe file version API",
+  "instructions": [
+    {
+      "agent_definition": {
+        "arguments": [
+          {
+            "name": "path",
+            "type_name": "string",
+            "description": "The API path for the request",
+            "required": true
+          },
+          {
+            "name": "fail_on_error",
+            "type_name": "bool",
+            "description": "Whether the agent run should fail in the case of an error",
+            "default_value": true,
+            "required": false
+          },
+          {
+            "name": "request",
+            "type_name": "object",
+            "description": "The API request object",
+            "required": true
+          },
+          {
+            "name": "target_service",
+            "type_name": "string",
+            "enum": ["PROCESS", "SCHEDULER", "STORAGE"],
+            "description": "The internal service to send the request to",
+            "required": true
+          }
+        ],
+        "responses": [
+          {
+            "name": "status_code",
+            "type_name": "number",
+            "description": "The responding status code from the API call",
+            "required": true
+          },
+          {
+            "name": "response_body",
+            "type_name": "object",
+            "description": "The response body from the API call",
+            "required": false
+          }
+        ],
+        "system_event_endpoint": "ratio::agent::internal_api::execution"
+      },
+      "arguments": {
+        "path": "/describe_file_version",
+        "target_service": "STORAGE",
+        "request": {
+          "file_path": "REF:arguments.file_path",
+          "version_id": "REF:arguments.version_id",
+          "include_lineage": "REF:arguments.include_lineage"
+        }
+      },
+      "execution_id": "describe_file_version_request"
+    },
+    {
+      "agent_definition": {
+        "arguments": [
+          {
+            "name": "original_object",
+            "type_name": "object",
+            "description": "The source object to be mapped",
+            "required": true
+          },
+          {
+            "name": "object_map",
+            "type_name": "object",
+            "description": "Mapping configuration that defines how to transform the original object",
+            "required": true
+          }
+        ],
+        "description": "Object mapper for describe file version response",
+        "responses": [
+          {
+            "name": "file_path",
+            "type_name": "string",
+            "description": "The full path of the file",
+            "required": true
+          },
+          {
+            "name": "file_name",
+            "type_name": "string",
+            "description": "The name of the file",
+            "required": true
+          },
+          {
+            "name": "version_id",
+            "type_name": "string",
+            "description": "The version ID of the file",
+            "required": true
+          },
+          {
+            "name": "metadata",
+            "type_name": "object",
+            "description": "Additional metadata associated with the file version",
+            "required": false
+          },
+          {
+            "name": "originator_id",
+            "type_name": "string",
+            "description": "The ID of the originator who created this version",
+            "required": true
+          },
+          {
+            "name": "origin",
+            "type_name": "string",
+            "description": "The origin of the file version (internal/external)",
+            "required": true
+          },
+          {
+            "name": "added_on",
+            "type_name": "string",
+            "description": "When the file version was added",
+            "required": true
+          },
+          {
+            "name": "previous_version_id",
+            "type_name": "string",
+            "description": "The version ID of the previous version",
+            "required": false
+          },
+          {
+            "name": "next_version_id",
+            "type_name": "string",
+            "description": "The version ID of the next version",
+            "required": false
+          }
+        ],
+        "system_event_endpoint": "ratio::agent::object_mapper::execution"
+      },
+      "arguments": {
+        "original_object": "REF:describe_file_version_request.response_body",
+        "object_map": {
+          "file_path": "file_path",
+          "file_name": "file_name",
+          "version_id": "version_id",
+          "metadata": "metadata",
+          "originator_id": "originator_id",
+          "origin": "origin",
+          "added_on": "added_on",
+          "previous_version_id": "previous_version_id",
+          "next_version_id": "next_version_id"
+        }
+      },
+      "execution_id": "map_response"
+    }
+  ],
+  "response_reference_map": {
+    "file_path": "REF:map_response.file_path",
+    "file_name": "REF:map_response.file_name",
+    "version_id": "REF:map_response.version_id",
+    "metadata": "REF:map_response.metadata",
+    "originator_id": "REF:map_response.originator_id",
+    "origin": "REF:map_response.origin",
+    "added_on": "REF:map_response.added_on",
+    "previous_version_id": "REF:map_response.previous_version_id",
+    "next_version_id": "REF:map_response.next_version_id"
+  },
+  "responses": [
+    {
+      "name": "file_path",
+      "type_name": "string",
+      "description": "The full path of the file",
+      "required": true
+    },
+    {
+      "name": "file_name",
+      "type_name": "string",
+      "description": "The name of the file",
+      "required": true
+    },
+    {
+      "name": "version_id",
+      "type_name": "string",
+      "description": "The version ID of the file",
+      "required": true
+    },
+    {
+      "name": "metadata",
+      "type_name": "object",
+      "description": "Additional metadata associated with the file version",
+      "required": false
+    },
+    {
+      "name": "originator_id",
+      "type_name": "string",
+      "description": "The ID of the originator who created this version",
+      "required": true
+    },
+    {
+      "name": "origin",
+      "type_name": "string",
+      "description": "The origin of the file version (internal/external)",
+      "required": true
+    },
+    {
+      "name": "added_on",
+      "type_name": "string",
+      "description": "When the file version was added",
+      "required": true
+    },
+    {
+      "name": "previous_version_id",
+      "type_name": "string",
+      "description": "The version ID of the previous version",
+      "required": false
+    },
+    {
+      "name": "next_version_id",
+      "type_name": "string",
+      "description": "The version ID of the next version",
+      "required": false
+    }
+  ]
+}

--- a/ratio/agents/internal_api/list_directory.agent
+++ b/ratio/agents/internal_api/list_directory.agent
@@ -1,0 +1,114 @@
+{
+  "arguments": [
+    {
+      "name": "directory_path",
+      "type_name": "string",
+      "description": "The full path of the directory to list",
+      "required": true
+    }
+  ],
+  "description": "A T2 agent that lists files in a directory by calling the storage manager's list files API and returns structured file information",
+  "instructions": [
+    {
+      "agent_definition": {
+        "arguments": [
+          {
+            "name": "path",
+            "type_name": "string",
+            "description": "The API path for the request",
+            "required": true
+          },
+          {
+            "name": "fail_on_error",
+            "type_name": "bool",
+            "description": "Whether the agent run should fail in the case of an error",
+            "default_value": true,
+            "required": false
+          },
+          {
+            "name": "request",
+            "type_name": "object",
+            "description": "The API request object",
+            "required": true
+          },
+          {
+            "name": "target_service",
+            "type_name": "string",
+            "enum": ["PROCESS", "SCHEDULER", "STORAGE"],
+            "description": "The internal service to send the request to",
+            "required": true
+          }
+        ],
+        "responses": [
+          {
+            "name": "status_code",
+            "type_name": "number",
+            "description": "The responding status code from the API call",
+            "required": true
+          },
+          {
+            "name": "response_body",
+            "type_name": "object",
+            "description": "The response body from the API call",
+            "required": false
+          }
+        ],
+        "system_event_endpoint": "ratio::agent::internal_api::execution"
+      },
+      "arguments": {
+        "path": "/list_files",
+        "target_service": "STORAGE",
+        "request": {
+          "file_path": "REF:arguments.directory_path"
+        }
+      },
+      "execution_id": "list_files_request"
+    },
+    {
+      "agent_definition": {
+        "arguments": [
+          {
+            "name": "original_object",
+            "type_name": "object",
+            "description": "The source object to be mapped",
+            "required": true
+          },
+          {
+            "name": "object_map",
+            "type_name": "object",
+            "description": "Mapping configuration that defines how to transform the original object",
+            "required": true
+          }
+        ],
+        "description": "Object mapper for list files response",
+        "responses": [
+          {
+            "name": "files",
+            "type_name": "list",
+            "description": "List of file objects from the directory",
+            "required": true
+          }
+        ],
+        "system_event_endpoint": "ratio::agent::object_mapper::execution"
+      },
+      "arguments": {
+        "original_object": "REF:list_files_request.response_body",
+        "object_map": {
+          "files": "files"
+        }
+      },
+      "execution_id": "map_response"
+    }
+  ],
+  "response_reference_map": {
+    "files": "REF:map_response.files"
+  },
+  "responses": [
+    {
+      "name": "files",
+      "type_name": "list",
+      "description": "List of file objects from the directory",
+      "required": true
+    }
+  ]
+}

--- a/ratio/agents/internal_api/list_file_versions.agent
+++ b/ratio/agents/internal_api/list_file_versions.agent
@@ -1,0 +1,114 @@
+{
+  "arguments": [
+    {
+      "name": "file_path",
+      "type_name": "string",
+      "description": "The full path of the file to list versions for",
+      "required": true
+    }
+  ],
+  "description": "A T2 agent that lists all versions of a file by calling the storage manager's list file versions API",
+  "instructions": [
+    {
+      "agent_definition": {
+        "arguments": [
+          {
+            "name": "path",
+            "type_name": "string",
+            "description": "The API path for the request",
+            "required": true
+          },
+          {
+            "name": "fail_on_error",
+            "type_name": "bool",
+            "description": "Whether the agent run should fail in the case of an error",
+            "default_value": true,
+            "required": false
+          },
+          {
+            "name": "request",
+            "type_name": "object",
+            "description": "The API request object",
+            "required": true
+          },
+          {
+            "name": "target_service",
+            "type_name": "string",
+            "enum": ["PROCESS", "SCHEDULER", "STORAGE"],
+            "description": "The internal service to send the request to",
+            "required": true
+          }
+        ],
+        "responses": [
+          {
+            "name": "status_code",
+            "type_name": "number",
+            "description": "The responding status code from the API call",
+            "required": true
+          },
+          {
+            "name": "response_body",
+            "type_name": "object",
+            "description": "The response body from the API call",
+            "required": false
+          }
+        ],
+        "system_event_endpoint": "ratio::agent::internal_api::execution"
+      },
+      "arguments": {
+        "path": "/list_file_versions",
+        "target_service": "STORAGE",
+        "request": {
+          "file_path": "REF:arguments.file_path"
+        }
+      },
+      "execution_id": "list_file_versions_request"
+    },
+    {
+      "agent_definition": {
+        "arguments": [
+          {
+            "name": "original_object",
+            "type_name": "object",
+            "description": "The source object to be mapped",
+            "required": true
+          },
+          {
+            "name": "object_map",
+            "type_name": "object",
+            "description": "Mapping configuration that defines how to transform the original object",
+            "required": true
+          }
+        ],
+        "description": "Object mapper for list file versions response",
+        "responses": [
+          {
+            "name": "versions",
+            "type_name": "list",
+            "description": "List of file version objects",
+            "required": true
+          }
+        ],
+        "system_event_endpoint": "ratio::agent::object_mapper::execution"
+      },
+      "arguments": {
+        "original_object": "REF:list_file_versions_request.response_body",
+        "object_map": {
+          "versions": "versions"
+        }
+      },
+      "execution_id": "map_response"
+    }
+  ],
+  "response_reference_map": {
+    "versions": "REF:map_response.versions"
+  },
+  "responses": [
+    {
+      "name": "versions",
+      "type_name": "list",
+      "description": "List of file version objects",
+      "required": true
+    }
+  ]
+}

--- a/ratio/core/services/agent_manager/runtime/event_handlers.py
+++ b/ratio/core/services/agent_manager/runtime/event_handlers.py
@@ -182,6 +182,14 @@ def _execute_children(claims: JWTClaims, execution_engine: ExecutionEngine, exec
     """
     base_working_dir = execution_engine.working_directory
 
+    if "agent_exec" not in base_working_dir:
+        logging.debug(f"Parent process working directory provided ... appending parent process directory")
+
+        base_working_dir = os.path.join(
+            base_working_dir,
+            f"agent_exec-{parent_process.process_id}",
+        )
+
     logging.debug(f"Base working directory for child processes: {base_working_dir}")
 
     # Create the event bus client

--- a/ratio/core/services/agent_manager/runtime/reference.py
+++ b/ratio/core/services/agent_manager/runtime/reference.py
@@ -322,10 +322,8 @@ class Reference:
             if attribute:
                 raise InvalidReferenceError("Attribute access is not supported for arguments.")
 
-            if key not in self.arguments:
-                raise InvalidReferenceError(f"Unknown argument key: {key}")
-
-            return self.arguments[key]
+            # Since default arguments are supported, need to let upstream handle None if that's the case
+            return self.arguments.get(key)
 
         # It's an execution_id
         if context not in self.responses:


### PR DESCRIPTION
- Support returning None as an argument, allowing it to be caught during the schema validation.
- Fix composite execution not using the parent process directory as working directory
- Add Internal API Agents
  - Delete Directory
  - Delete File
  - Describe File Version
  - List File Versions
  - List Files