### PR TITLE
Add support for conditional agent execution

### DIFF
--- a/ratio/agents/agent_lib/events.py
+++ b/ratio/agents/agent_lib/events.py
@@ -99,15 +99,15 @@ class SystemExecuteAgentResponse(ObjectBodySchema):
             required=False,
         ),
         SchemaAttribute(
-            name="token",
-            type_name=SchemaAttributeType.STRING,
-            description="The token to use for authentication",
-            required=True,
-        ),
-        SchemaAttribute(
             name="status",
             type_name=SchemaAttributeType.STRING,
             description="The status of the agent execution",
+            required=True,
+        ),
+        SchemaAttribute(
+            name="token",
+            type_name=SchemaAttributeType.STRING,
+            description="The token to use for authentication",
             required=True,
         ),
     ]

--- a/ratio/core/services/agent_manager/request_definitions.py
+++ b/ratio/core/services/agent_manager/request_definitions.py
@@ -103,6 +103,58 @@ class AgentDefinitionSchema(ObjectBodySchema):
   ]
 
 
+class ConditionSchema(ObjectBodySchema):
+    attributes = [
+        SchemaAttribute(
+            name="param",
+            type_name=SchemaAttributeType.STRING,
+            description="REF string to the parameter to evaluate",
+            required=True,
+        ),
+        SchemaAttribute(
+            name="operator",
+            type_name=SchemaAttributeType.STRING,
+            description="Comparison operator",
+            required=True,
+            enum=[
+                "equals",
+                "not_equals",
+                "greater_than",
+                "less_than",
+                "exists",
+                "not_exists",
+                "contains",
+                "in",
+                "starts_with"
+            ]
+        ),
+        SchemaAttribute(
+            name="value",
+            type_name=SchemaAttributeType.ANY,
+            description="Value to compare against",
+            required=False,
+        ),
+    ]
+
+class ConditionGroupSchema(ObjectBodySchema):
+    attributes = [
+        SchemaAttribute(
+            name="logic",
+            type_name=SchemaAttributeType.STRING,
+            description="Logic operator for this group",
+            required=False,
+            default_value="AND",
+            enum=["AND", "OR"]
+        ),
+        SchemaAttribute(
+            name="conditions",
+            type_name=SchemaAttributeType.OBJECT_LIST,
+            description="List of conditions or nested condition groups",
+            required=True,
+        ),
+    ]
+
+
 class DescribeProcessRequest(ObjectBodySchema):
     """
     Schema for describing a process. This is used to get the details of a process that is currently running.
@@ -151,11 +203,17 @@ class ExecuteAgentRequest(ObjectBodySchema):
             ]
         ),
         SchemaAttribute(
-           name="execute_as",
-           type_name=SchemaAttributeType.STRING,
-           description="The entity to execute the agent as. This is the entity that will be used to execute the agent. ONLY SUPPORTED IF THE REQUESTOR IS AN ADMIN",
-           required=False,
-           regex_pattern="^[a-z0-9_\\-]+$",
+            name="conditions",
+            type_name=SchemaAttributeType.OBJECT_LIST,
+            description="A list of conditions to evaluate before executing the agent. This is used to determine if the agent should be executed or not",
+            required=False,
+        ),
+        SchemaAttribute(
+            name="execute_as",
+            type_name=SchemaAttributeType.STRING,
+            description="The entity to execute the agent as. This is the entity that will be used to execute the agent. ONLY SUPPORTED IF THE REQUESTOR IS AN ADMIN",
+            required=False,
+            regex_pattern="^[a-z0-9_\\-]+$",
         ),
         SchemaAttribute(
             name="working_directory",

--- a/ratio/core/services/agent_manager/runtime/agent.py
+++ b/ratio/core/services/agent_manager/runtime/agent.py
@@ -217,6 +217,7 @@ class AgentInstruction:
     """
     definition: AgentDefinition
     execution_id: str
+    conditions: List[Dict] = None
     response: Dict[str, Any] = None
     provided_arguments: Dict[str, Any] = None
 
@@ -224,6 +225,9 @@ class AgentInstruction:
         """
         Post-initialization method to set default values for the agent instruction.
         """
+        if self.conditions is None:
+            self.conditions = []
+
         if self.response is None:
             self.response = {}
 
@@ -233,6 +237,11 @@ class AgentInstruction:
     def _load_aio(self, file_path: str, token: str, parameter_name: str):
         """
         Loads an agent IO file from the given path
+
+        Keyword arguments:
+        file_path -- The path to the agent IO file
+        token -- The token to use for authentication
+        parameter_name -- The name of the parameter to load
         """
         internal_client = RatioInternalClient(service_name="storage_manager", token=token)
 

--- a/ratio/core/services/agent_manager/runtime/conditions.py
+++ b/ratio/core/services/agent_manager/runtime/conditions.py
@@ -1,0 +1,194 @@
+"""
+ConditionEvaluator
+
+This module provides a class for evaluating conditions based on a reference object.
+"""
+import logging
+
+from typing import Any, Dict, List, Union
+
+from ratio.core.services.agent_manager.runtime.reference import Reference
+
+
+class ConditionEvaluator:
+    def __init__(self, reference: Reference, token: str):
+        """
+        Initialize the ConditionEvaluator with a reference and token.
+
+        Keyword arguments:
+        reference -- A Reference object to resolve parameters
+        token -- A token to be used for resolving parameters
+        """
+        self.reference = reference
+
+        self.token = token
+
+    def evaluate(self, conditions: Union[List, Dict]) -> bool:
+        """
+        Main entry point for condition evaluation
+
+        Keyword arguments:
+        conditions -- A list of conditions or a condition group
+        """
+        if isinstance(conditions, list):
+            # Simple list of conditions (backward compatibility)
+            return self._evaluate_condition_list(conditions, "AND")
+
+        if isinstance(conditions, dict):
+            # Structured condition object
+            return self._evaluate_condition_group(conditions)
+
+        return True  # No conditions
+
+    def _evaluate_condition_group(self, group: Dict) -> bool:
+        """
+        Evaluate a condition group (with potential nested groups)
+
+        Keyword arguments:
+        group -- A dictionary representing a condition group
+        """
+        logic = group.get("logic", "AND")
+
+        # Evaluate direct conditions in this group
+        direct_conditions = group.get("conditions", [])
+
+        direct_results = []
+
+        for condition in direct_conditions:
+            result = self._evaluate_single_condition(condition)
+
+            direct_results.append(result)
+
+        # Evaluate nested groups
+        nested_groups = group.get("groups", [])
+
+        nested_results = []
+
+        for nested_group in nested_groups:
+            result = self._evaluate_condition_group(nested_group)
+
+            nested_results.append(result)
+
+        # Combine all results
+        all_results = direct_results + nested_results
+
+        if not all_results:
+            return True  # Empty group passes
+
+        if logic == "AND":
+            return all(all_results)
+
+        else:  # OR
+            return any(all_results)
+
+    def _evaluate_condition_list(self, conditions: List, logic: str = "AND") -> bool:
+        """
+        Evaluate a simple list of conditions
+
+        Keyword arguments:
+        conditions -- A list of conditions
+        logic -- The logic to apply (AND/OR)
+        """
+        if not conditions:
+            return True
+
+        results = []
+
+        for condition in conditions:
+            result = self._evaluate_single_condition(condition)
+
+            results.append(result)
+
+        if logic == "AND":
+            return all(results)
+
+        else:  # OR
+            return any(results)
+
+    def _evaluate_single_condition(self, condition: Dict) -> bool:
+        """
+        Evaluate a single condition
+
+        Keyword arguments:
+        condition -- A dictionary representing a single condition
+        """
+        try:
+            param_value = condition["param"]
+
+            if condition["param"].startswith("REF:"):
+                logging.debug(f"Resolving reference for {param_value}")
+
+                # Special case for ratio parameters
+                param_value = self.reference.resolve(
+                    reference_string=condition["param"], 
+                    token=self.token
+                )
+
+                logging.debug(f"Resolved value: {param_value}")
+
+            operator = condition["operator"]
+
+            expected_value = condition.get("value")
+
+            return self._apply_operator(param_value, operator, expected_value)
+
+        except Exception as e:
+            logging.warning(f"Condition evaluation failed: {e}")
+
+            return False
+
+    def _apply_operator(self, actual: Any, operator: str, expected: Any) -> bool:
+        """
+        Apply the comparison operator
+
+        Keyword arguments:
+        actual -- The actual value to compare
+        operator -- The operator to apply
+        expected -- The expected value to compare against
+        """
+        logging.debug(f"Applying operator: {operator} on {actual} and {expected}")
+
+        if operator == "equals":
+            return actual == expected
+
+        elif operator == "not_equals":
+            return actual != expected
+
+        elif operator == "exists":
+            return actual is not None
+
+        elif operator == "not_exists":
+            return actual is None
+
+        elif operator == "greater_than":
+            return actual > expected
+
+        elif operator == "less_than":
+            return actual < expected
+
+        elif operator == "greater_than_or_equal":
+            return actual >= expected
+
+        elif operator == "less_than_or_equal":
+            return actual <= expected
+
+        elif operator == "contains":
+            return expected in actual
+
+        elif operator == "not_contains":
+            return expected not in actual
+
+        elif operator == "in":
+            return actual in expected
+
+        elif operator == "not_in":
+            return actual not in expected
+
+        elif operator == "starts_with":
+            return str(actual).startswith(str(expected))
+
+        elif operator == "ends_with":
+            return str(actual).endswith(str(expected))
+
+        else:
+            raise ValueError(f"Unknown operator: {operator}")

--- a/ratio/core/services/agent_manager/runtime/conditions_test.py
+++ b/ratio/core/services/agent_manager/runtime/conditions_test.py
@@ -1,0 +1,337 @@
+"""
+Quick test script for the ConditionEvaluator class
+"""
+
+import logging
+from typing import Any, Dict, List, Union
+from unittest.mock import Mock
+
+# Set up logging
+logging.basicConfig(level=logging.INFO)
+
+class MockReference:
+    """Mock reference resolver for testing"""
+    def __init__(self):
+        self.values = {
+            "REF:user.active": True,
+            "REF:user.level": "admin",
+            "REF:user.permissions": ["read", "write", "execute"],
+            "REF:data.count": 25,
+            "REF:data.status": "ready",
+            "REF:quota.remaining": 100,
+            "REF:environment.type": "production",
+            "REF:override.enabled": False,
+            "REF:arguments.force": True,
+            "REF:previous.success": True,
+            "REF:score.value": 85.5,
+        }
+    
+    def resolve(self, reference_string: str, token: str = None) -> Any:
+        if reference_string in self.values:
+            return self.values[reference_string]
+        raise ValueError(f"Unknown reference: {reference_string}")
+
+class ConditionEvaluator:
+    def __init__(self, reference, token: str = "mock_token"):
+        self.reference = reference
+        self.token = token
+    
+    def evaluate(self, conditions: Union[List, Dict]) -> bool:
+        """Main entry point for condition evaluation"""
+        if isinstance(conditions, list):
+            # Simple list of conditions (backward compatibility)
+            return self._evaluate_condition_list(conditions, "AND")
+        
+        if isinstance(conditions, dict):
+            # Structured condition object
+            return self._evaluate_condition_group(conditions)
+        
+        return True  # No conditions
+    
+    def _evaluate_condition_group(self, group: Dict) -> bool:
+        """Evaluate a condition group (with potential nested groups)"""
+        logic = group.get("logic", "AND")
+        
+        # Evaluate direct conditions in this group
+        direct_conditions = group.get("conditions", [])
+        direct_results = []
+        
+        for condition in direct_conditions:
+            result = self._evaluate_single_condition(condition)
+            direct_results.append(result)
+        
+        # Evaluate nested groups
+        nested_groups = group.get("groups", [])
+        nested_results = []
+        
+        for nested_group in nested_groups:
+            result = self._evaluate_condition_group(nested_group)
+            nested_results.append(result)
+        
+        # Combine all results
+        all_results = direct_results + nested_results
+        
+        if not all_results:
+            return True  # Empty group passes
+        
+        if logic == "AND":
+            return all(all_results)
+        else:  # OR
+            return any(all_results)
+    
+    def _evaluate_condition_list(self, conditions: List, logic: str = "AND") -> bool:
+        """Evaluate a simple list of conditions"""
+        if not conditions:
+            return True
+        
+        results = []
+        for condition in conditions:
+            result = self._evaluate_single_condition(condition)
+            results.append(result)
+        
+        if logic == "AND":
+            return all(results)
+        else:  # OR
+            return any(results)
+    
+    def _evaluate_single_condition(self, condition: Dict) -> bool:
+        """Evaluate a single condition"""
+        try:
+            param_value = condition["param"]
+            if condition["param"].startswith("REF:"):
+                # Special case for ratio parameters
+                param_value = self.reference.resolve(
+                    reference_string=condition["param"], 
+                    token=self.token
+                )
+            
+            operator = condition["operator"]
+            expected_value = condition.get("value")
+            
+            return self._apply_operator(param_value, operator, expected_value)
+        
+        except Exception as e:
+            logging.warning(f"Condition evaluation failed: {e}")
+            return False
+    
+    def _apply_operator(self, actual: Any, operator: str, expected: Any) -> bool:
+        """Apply the comparison operator"""
+        if operator == "equals":
+            return actual == expected
+        elif operator == "not_equals":
+            return actual != expected
+        elif operator == "exists":
+            return actual is not None
+        elif operator == "not_exists":
+            return actual is None
+        elif operator == "greater_than":
+            return actual > expected
+        elif operator == "less_than":
+            return actual < expected
+        elif operator == "greater_than_or_equal":
+            return actual >= expected
+        elif operator == "less_than_or_equal":
+            return actual <= expected
+        elif operator == "contains":
+            return expected in actual
+        elif operator == "not_contains":
+            return expected not in actual
+        elif operator == "in":
+            return actual in expected
+        elif operator == "not_in":
+            return actual not in expected
+        elif operator == "starts_with":
+            return str(actual).startswith(str(expected))
+        elif operator == "ends_with":
+            return str(actual).endswith(str(expected))
+        else:
+            raise ValueError(f"Unknown operator: {operator}")
+
+def run_tests():
+    """Run test cases for the ConditionEvaluator"""
+    
+    # Set up mock reference and evaluator
+    mock_ref = MockReference()
+    evaluator = ConditionEvaluator(mock_ref)
+    
+    # Test cases
+    test_cases = [
+        # Simple condition list (backward compatibility)
+        {
+            "name": "Simple list - all true",
+            "conditions": [
+                {"param": "REF:user.active", "operator": "equals", "value": True},
+                {"param": "REF:data.count", "operator": "greater_than", "value": 10}
+            ],
+            "expected": True
+        },
+        
+        # Static value conditions (your improvement)
+        {
+            "name": "Static value condition",
+            "conditions": [
+                {"param": "static_value", "operator": "equals", "value": "static_value"},
+                {"param": "REF:user.active", "operator": "equals", "value": True}
+            ],
+            "expected": True
+        },
+        
+        # Simple group with AND logic
+        {
+            "name": "Simple AND group",
+            "conditions": {
+                "logic": "AND",
+                "conditions": [
+                    {"param": "REF:user.active", "operator": "equals", "value": True},
+                    {"param": "REF:user.level", "operator": "equals", "value": "admin"}
+                ]
+            },
+            "expected": True
+        },
+        
+        # Simple group with OR logic
+        {
+            "name": "Simple OR group",
+            "conditions": {
+                "logic": "OR",
+                "conditions": [
+                    {"param": "REF:user.level", "operator": "equals", "value": "user"},  # False
+                    {"param": "REF:user.active", "operator": "equals", "value": True}   # True
+                ]
+            },
+            "expected": True
+        },
+        
+        # Complex nested groups
+        {
+            "name": "Complex nested groups",
+            "conditions": {
+                "logic": "AND",
+                "groups": [
+                    {
+                        "logic": "OR",
+                        "conditions": [
+                            {"param": "REF:data.status", "operator": "equals", "value": "ready"},
+                            {"param": "REF:arguments.force", "operator": "equals", "value": True}
+                        ]
+                    },
+                    {
+                        "logic": "AND",
+                        "conditions": [
+                            {"param": "REF:user.permissions", "operator": "contains", "value": "execute"},
+                            {"param": "REF:quota.remaining", "operator": "greater_than", "value": 0}
+                        ]
+                    }
+                ]
+            },
+            "expected": True
+        },
+        
+        # Test with various operators
+        {
+            "name": "Various operators",
+            "conditions": {
+                "logic": "AND",
+                "conditions": [
+                    {"param": "REF:user.level", "operator": "in", "value": ["admin", "superuser"]},
+                    {"param": "REF:user.permissions", "operator": "contains", "value": "write"},
+                    {"param": "REF:score.value", "operator": "greater_than_or_equal", "value": 80.0},
+                    {"param": "REF:environment.type", "operator": "starts_with", "value": "prod"}
+                ]
+            },
+            "expected": True
+        },
+        
+        # Test failure case
+        {
+            "name": "Failure case",
+            "conditions": {
+                "logic": "AND",
+                "conditions": [
+                    {"param": "REF:user.active", "operator": "equals", "value": True},
+                    {"param": "REF:user.level", "operator": "equals", "value": "superuser"}  # False
+                ]
+            },
+            "expected": False
+        },
+        
+        # Test exists/not_exists
+        {
+            "name": "Exists operators",
+            "conditions": [
+                {"param": "REF:user.active", "operator": "exists"},
+                {"param": "REF:nonexistent.field", "operator": "not_exists"}
+            ],
+            "expected": False  # Second condition will fail with exception, returning False
+        },
+        
+        # Empty conditions (should pass)
+        {
+            "name": "Empty conditions",
+            "conditions": [],
+            "expected": True
+        },
+        
+        # Empty group (should pass)
+        {
+            "name": "Empty group",
+            "conditions": {
+                "logic": "AND",
+                "conditions": []
+            },
+            "expected": True
+        }
+    ]
+    
+    # Run tests
+    passed = 0
+    failed = 0
+    
+    for test_case in test_cases:
+        try:
+            result = evaluator.evaluate(test_case["conditions"])
+            if result == test_case["expected"]:
+                print(f"✅ {test_case['name']}: PASSED")
+                passed += 1
+            else:
+                print(f"❌ {test_case['name']}: FAILED - expected {test_case['expected']}, got {result}")
+                failed += 1
+        except Exception as e:
+            print(f"💥 {test_case['name']}: ERROR - {e}")
+            failed += 1
+    
+    print(f"\n📊 Results: {passed} passed, {failed} failed")
+    
+    # Demonstrate usage
+    print("\n" + "="*50)
+    print("DEMONSTRATION")
+    print("="*50)
+    
+    # Show how to use it
+    demo_conditions = {
+        "logic": "AND",
+        "groups": [
+            {
+                "logic": "OR",
+                "conditions": [
+                    {"param": "REF:environment.type", "operator": "equals", "value": "development"},
+                    {"param": "REF:override.enabled", "operator": "equals", "value": True}
+                ]
+            },
+            {
+                "conditions": [
+                    {"param": "REF:user.active", "operator": "equals", "value": True}
+                ]
+            }
+        ]
+    }
+    
+    print("Demo condition structure:")
+    import json
+    print(json.dumps(demo_conditions, indent=2))
+    
+    result = evaluator.evaluate(demo_conditions)
+    print(f"\nEvaluation result: {result}")
+
+if __name__ == "__main__":
+    run_tests()

--- a/ratio/core/services/agent_manager/runtime/no_op.py
+++ b/ratio/core/services/agent_manager/runtime/no_op.py
@@ -1,0 +1,236 @@
+import json
+import logging
+import os
+
+from datetime import datetime, UTC as utc_tz
+from typing import List, Union
+
+from da_vinci.core.immutable_object import ObjectBody
+
+from da_vinci.event_bus.client import EventPublisher
+from da_vinci.event_bus.event import Event as EventBusEvent
+
+from ratio.core.core_lib.client import RatioInternalClient
+from ratio.core.core_lib.jwt import JWTClaims
+
+from ratio.core.services.storage_manager.request_definitions import (
+    PutFileRequest,
+    PutFileVersionRequest,
+)
+
+from ratio.core.services.agent_manager.runtime.events import (
+    SystemExecuteAgentResponse,
+)
+
+from ratio.core.services.agent_manager.tables.processes.client import (
+    Process,
+    ProcessStatus,
+    ProcessTableClient,
+)
+
+from ratio.core.services.agent_manager.runtime.engine import (
+    AGENT_IO_FILE_TYPE,
+    AIO_EXT,
+    ExecutionEngine,
+)
+
+def _create_noop_response_file(execution_id: str, process_id: str, execution_engine: ExecutionEngine,
+                               token: str) -> Union[str, None]:
+    """
+    Create a response file for the no-op execution.
+    Returns the path to the created response file, or None if no responses expected.
+
+    Keyword arguments:
+    execution_id -- The ID of the execution to create a response file for.
+    process_id -- The ID of the process to create a response file for.
+    execution_engine -- The execution engine to use for creating the response file.
+    token -- The JWT token to use for creating the response file.
+    """
+    instruction = execution_engine.instructions[execution_id]
+
+    # If no responses expected, don't create a file
+    if not instruction.definition.responses:
+        logging.debug(f"No responses expected for {execution_id}, skipping response file creation")
+
+        return None
+
+    # Build the null response object
+    null_responses = {}
+
+    for response_definition in instruction.definition.responses:
+
+        response_name = response_definition["name"]
+
+        response_type = response_definition["type_name"]
+
+        # Create appropriate null value based on type
+        if response_type == "list":
+            null_responses[response_name] = []
+
+        elif response_type == "object":
+            null_responses[response_name] = {}
+
+        else:
+            null_responses[response_name] = None
+
+    # Use the standard response file path (in the process-specific directory)
+    process_working_dir = execution_engine.get_path(
+        working_dir=execution_engine.get_path(),
+        process_id=process_id,
+    )
+
+    response_path = os.path.join(process_working_dir, "response" + AIO_EXT)
+
+    # Create storage client
+    storage_client = RatioInternalClient(service_name="storage_manager", token=token)
+
+    # Create file metadata
+    put_file_request = ObjectBody(
+        schema=PutFileRequest,
+        body={
+            "file_path": response_path,
+            "file_type": AGENT_IO_FILE_TYPE,
+            "metadata": {
+                "description": "No-op response (conditions not met)",
+                "execution_id": execution_id,
+                "process_id": process_id,
+                "execution_type": "noop",
+                "skip_reason": "conditions_not_met"
+            },
+            "permissions": "444",
+        }
+    )
+
+    put_file_resp = storage_client.request(
+        path="/put_file",
+        request=put_file_request
+    )
+
+    if put_file_resp.status_code not in [200, 201]:
+        raise Exception(f"Failed to create no-op response file: {put_file_resp.status_code} -- {put_file_resp.body}")
+
+    # Put the file content
+    put_file_version_request = ObjectBody(
+        schema=PutFileVersionRequest,
+        body={
+            "file_path": response_path,
+            "data": json.dumps(null_responses),
+            "metadata": {
+                "execution_id": execution_id,
+                "execution_type": "noop"
+            },
+            "origin": "internal",
+            "source_files": [],
+        }
+    )
+
+    put_version_resp = storage_client.request(
+        path="/put_file_version",
+        request=put_file_version_request
+    )
+
+    if put_version_resp.status_code not in [200, 201]:
+        raise Exception(f"Failed to put no-op response file version: {put_version_resp.status_code} -- {put_version_resp.body}")
+
+    logging.debug(f"Created no-op response file: {response_path}")
+
+    return response_path
+
+
+def execute_no_ops(skipped_ids: List[str], execution_engine: ExecutionEngine,  parent_process: Process,
+                    process_client: ProcessTableClient, claims: JWTClaims, token: str):
+    """
+    Execute no-op agents for skipped executions.
+    Creates processes, prepares them normally, then immediately completes with null responses.
+
+    Keyword arguments:
+    skipped_ids -- The list of execution IDs to execute no-ops for.
+    execution_engine -- The execution engine to use for preparing the no-op agents.
+    parent_process -- The parent process to use for creating child processes.
+    process_client -- The process client to use for saving the processes.
+    claims -- The JWT claims to use for creating the child processes.
+    token -- The JWT token to use for creating the child processes.
+    """
+    event_publisher = EventPublisher()
+
+    for execution_id in skipped_ids:
+        logging.info(f"Executing no-op for {execution_id} (conditions not met)")
+
+        # Create child process just like normal execution
+        child_proc = parent_process.create_child(
+            execution_id=execution_id,
+            execution_status=ProcessStatus.SKIPPED,
+            working_directory=execution_engine.get_path(),
+            process_owner=claims.entity,
+        )
+
+        try:
+            # Prepare for execution just like normal agents
+            execution_engine.prepare_for_execution(
+                agent_instruction=execution_engine.instructions[execution_id],
+                process_id=child_proc.process_id,
+                working_directory=execution_engine.get_path(),
+            )
+
+            # Create null responses and save response file
+            response_path = _create_noop_response_file(
+                execution_id, 
+                child_proc.process_id, 
+                execution_engine,
+                token
+            )
+
+            child_proc.response_path = response_path
+
+            child_proc.ended_on = datetime.now(tz=utc_tz)
+
+            process_client.put(child_proc)
+
+            execution_engine.mark_completed(
+                execution_id=execution_id,
+                response_path=response_path,
+            )
+
+            # Send success response event to trigger process complete handler
+            event_body = ObjectBody(
+                body={
+                    "parent_process_id": parent_process.process_id,
+                    "process_id": child_proc.process_id,
+                    "response": response_path,
+                    "status": "success",
+                    "token": token,
+                },
+                schema=SystemExecuteAgentResponse,
+            )
+
+            response_event = EventBusEvent(
+                body=event_body,
+                event_type="ratio::agent_response"
+            )
+
+            # Delay the event to allow the system time to get it's processes to a running state to avoid possible duplication
+            event_publisher.submit(event=response_event, delay=10)
+
+            logging.info(f"No-op execution completed for {execution_id}, response event sent")
+
+        except Exception as e:
+            logging.error(f"Failed to execute no-op for {execution_id}: {e}")
+
+            # Send failure response event
+            event_body = ObjectBody(
+                body={
+                    "failure": f"No-op preparation failed: {str(e)}",
+                    "parent_process_id": parent_process.process_id,
+                    "process_id": child_proc.process_id,
+                    "status": "failure",
+                    "token": token,
+                },
+                schema=SystemExecuteAgentResponse,
+            )
+
+            response_event = EventBusEvent(
+                body=event_body,
+                event_type="ratio::agent_response"
+            )
+
+            event_publisher.submit(event=response_event)

--- a/ratio/core/services/agent_manager/runtime/reference.py
+++ b/ratio/core/services/agent_manager/runtime/reference.py
@@ -319,6 +319,8 @@ class Reference:
         context, key, attribute = self.parse_ref(reference_string)
 
         if context == "arguments":
+            logging.debug(f"Resolving argument: {key} from {self.arguments}")
+
             if attribute:
                 raise InvalidReferenceError("Attribute access is not supported for arguments.")
 

--- a/ratio/core/services/agent_manager/tables/processes/client.py
+++ b/ratio/core/services/agent_manager/tables/processes/client.py
@@ -21,6 +21,7 @@ class ProcessStatus(StrEnum):
     COMPLETED = "COMPLETED"
     FAILED = "FAILED"
     RUNNING = "RUNNING"
+    SKIPPED = "SKIPPED"
     TERMINATED = "TERMINATED"
 
 
@@ -67,6 +68,13 @@ class Process(TableObject):
         ),
 
         TableObjectAttribute(
+            name="execution_status",
+            attribute_type=TableObjectAttributeType.STRING,
+            description="The status of the process.",
+            default=ProcessStatus.RUNNING,
+        ),
+
+        TableObjectAttribute(
             name="process_owner",
             attribute_type=TableObjectAttributeType.STRING,
             description="The owner of the process.",
@@ -78,13 +86,6 @@ class Process(TableObject):
             attribute_type=TableObjectAttributeType.STRING,
             description="The path to the response of the process.",
             optional=True,
-        ),
-
-        TableObjectAttribute(
-            name="execution_status",
-            attribute_type=TableObjectAttributeType.STRING,
-            description="The status of the process.",
-            default=ProcessStatus.RUNNING,
         ),
 
         TableObjectAttribute(
@@ -109,19 +110,21 @@ class Process(TableObject):
         ),
     ]
 
-    def create_child(self, execution_id: str, working_directory: str, process_owner: Optional[str] = None,
-                     process_id: Optional[str] = None) -> None:
+    def create_child(self, execution_id: str, working_directory: str, execution_status: Optional[str] = None,
+                     process_owner: Optional[str] = None, process_id: Optional[str] = None) -> None:
         """
         Create a child process.
 
         Keyword arguments:
         execution_id -- The execution id of the child process.
         working_directory -- The working directory of the child process.
+        execution_status -- The status of the child process. If not provided, the status will be set to RUNNING.
         process_owner -- The owner of the child process.
         process_id -- The id of the child process. If not provided, a new id will be generated.
         """
         return Process(
             execution_id=execution_id,
+            execution_status=execution_status,
             parent_process_id=self.process_id,
             working_directory=working_directory,
             process_owner=process_owner or self.process_owner,


### PR DESCRIPTION
Agent instructions support optional conditions which takes condition statements, calculated at the time of expected execution.

When a conditional agent is not executed, the system executes no-op which places the would-be arguments into the directory as well as dropping null responses for any results.