### PR TITLE
Improve the Ratio Shell Bash Script

### DIFF
--- a/rto/commands/authorization.py
+++ b/rto/commands/authorization.py
@@ -18,6 +18,7 @@ from ratio.client.requests.auth import (
 )
 
 from rto.commands.base import RTOCommand, RTOErrorMessage
+from rto.config import RTOConfig
 from rto.keys import generate_rsa_key_pair
 
 
@@ -55,12 +56,13 @@ class CreateEntityCommand(RTOCommand):
 
         parser.add_argument("--json", help="Output raw JSON response", action="store_true", default=False)
 
-    def execute(self, client: Ratio, args):
+    def execute(self, client: Ratio, config: RTOConfig, args):
         """
         Execute the command.
         """
         # Get or generate key pair
         public_key_value = None
+
         private_key_value = None
 
         if args.public_key:
@@ -160,7 +162,7 @@ class CreateGroupCommand(RTOCommand):
 
         parser.add_argument("--json", help="Output raw JSON response", action="store_true", default=False)
 
-    def execute(self, client: Ratio, args):
+    def execute(self, client: Ratio, config: RTOConfig, args):
         """
         Execute the command.
         """
@@ -218,7 +220,7 @@ class AddEntityToGroupCommand(RTOCommand):
 
         parser.add_argument("--json", help="Output raw JSON response", action="store_true", default=False)
 
-    def execute(self, client: Ratio, args):
+    def execute(self, client: Ratio, config: RTOConfig, args):
         """
         Execute the command.
         """
@@ -286,7 +288,7 @@ class RemoveEntityFromGroupCommand(RTOCommand):
 
         parser.add_argument("--json", help="Output raw JSON response", action="store_true", default=False)
 
-    def execute(self, client: Ratio, args):
+    def execute(self, client: Ratio, config: RTOConfig, args):
         """
         Execute the command.
         """
@@ -360,7 +362,7 @@ class DeleteGroupCommand(RTOCommand):
 
         parser.add_argument("--json", help="Output raw JSON response", action="store_true", default=False)
 
-    def execute(self, client: Ratio, args):
+    def execute(self, client: Ratio, config: RTOConfig, args):
         """
         Execute the command.
         """
@@ -433,7 +435,7 @@ class DeleteEntityCommand(RTOCommand):
 
         parser.add_argument("--json", help="Output raw JSON response", action="store_true", default=False)
 
-    def execute(self, client: Ratio, args):
+    def execute(self, client: Ratio, config: RTOConfig, args):
         """
         Execute the command.
         """
@@ -500,7 +502,7 @@ class DescribeGroupCommand(RTOCommand):
 
         parser.add_argument("--json", help="Output raw JSON response", action="store_true", default=False)
 
-    def execute(self, client: Ratio, args):
+    def execute(self, client: Ratio, config: RTOConfig, args):
         """
         Execute the command.
         """
@@ -582,7 +584,7 @@ class DescribeEntityCommand(RTOCommand):
 
         parser.add_argument("--json", help="Output raw JSON response", action="store_true", default=False)
 
-    def execute(self, client: Ratio, args):
+    def execute(self, client: Ratio, config: RTOConfig, args):
         """
         Execute the command.
         """
@@ -674,7 +676,7 @@ class ListEntitiesCommand(RTOCommand):
 
         parser.add_argument("--detailed", "-d", help="Show detailed entity information", action="store_true", default=False)
 
-    def execute(self, client: Ratio, args):
+    def execute(self, client: Ratio, config: RTOConfig, args):
         """
         Execute the command.
         """
@@ -792,7 +794,7 @@ class ListGroupsCommand(RTOCommand):
         parser.add_argument("--json", help="Output raw JSON response", action="store_true", default=False)
         parser.add_argument("--detailed", "-d", help="Show detailed group information", action="store_true", default=False)
 
-    def execute(self, client: Ratio, args):
+    def execute(self, client: Ratio, config: RTOConfig, args):
         """
         Execute the command.
         """
@@ -888,7 +890,7 @@ class RotateEntityKeyCommand(RTOCommand):
 
         parser.add_argument("--json", help="Output raw JSON response", action="store_true", default=False)
 
-    def execute(self, client: Ratio, args):
+    def execute(self, client: Ratio, config: RTOConfig, args):
         """
         Execute the command.
         """

--- a/rto/commands/base.py
+++ b/rto/commands/base.py
@@ -2,6 +2,8 @@ from argparse import ArgumentParser
 
 from ratio.client.client import Ratio
 
+from rto.config import RTOConfig
+
 
 class RTOErrorMessage(Exception):
     """
@@ -20,7 +22,7 @@ class RTOCommand:
     def configure_parser(cls, parser: ArgumentParser):
         return
 
-    def execute(self, client: Ratio, args):
+    def execute(self, client: Ratio, config: RTOConfig, args):
         raise NotImplementedError
 
     def ratio_client(self, args):

--- a/rto/commands/config.py
+++ b/rto/commands/config.py
@@ -32,7 +32,7 @@ class ConfigureCommand(RTOCommand):
 
         parser.add_argument("--non-interactive", help="Don't prompt for missing values", action="store_true", default=False)
 
-    def execute(self, client: Ratio, args):
+    def execute(self, client: Ratio, config: RTOConfig, args):
         """
         Execute the command.
 
@@ -40,8 +40,6 @@ class ConfigureCommand(RTOCommand):
         client -- Ratio client instance
         args -- the parsed arguments
         """
-        config = RTOConfig()
-
         # Use the distinct argument name
         profile_name = args.name
 
@@ -136,12 +134,10 @@ class GetCurrentProfileCommand(RTOCommand):
         """
         parser.add_argument("--json", help="Output as JSON", action="store_true", default=False)
 
-    def execute(self, client: Ratio, args):
+    def execute(self, client: Ratio, config: RTOConfig, args):
         """
         Execute the command.
         """
-        config = RTOConfig(config_dir=args.config_path)
-
         # Get profile info
         profile_name = args.profile or config.get_default_profile()
 

--- a/rto/commands/file_types.py
+++ b/rto/commands/file_types.py
@@ -11,6 +11,7 @@ from ratio.client.requests.storage import (
 )
 
 from rto.commands.base import RTOCommand, RTOErrorMessage
+from rto.config import RTOConfig
 
 
 class DeleteFileTypeCommand(RTOCommand):
@@ -34,7 +35,7 @@ class DeleteFileTypeCommand(RTOCommand):
 
         parser.add_argument("--json", help="Output raw JSON response", action="store_true", default=False)
 
-    def execute(self, client: Ratio, args):
+    def execute(self, client: Ratio, config: RTOConfig, args):
         """
         Execute the command.
 
@@ -99,7 +100,7 @@ class DescribeFileTypeCommand(RTOCommand):
 
         parser.add_argument("--json", help="Output raw JSON response", action="store_true", default=False)
 
-    def execute(self, client: Ratio, args):
+    def execute(self, client: Ratio, config: RTOConfig, args):
         """
         Execute the command.
 
@@ -198,7 +199,7 @@ class ListFileTypesCommand(RTOCommand):
 
         parser.add_argument("--filter", help="Filter file types by substring (case-insensitive)", type=str)
 
-    def execute(self, client: Ratio, args):
+    def execute(self, client: Ratio, config: RTOConfig, args):
         """
         Execute the command.
         
@@ -331,7 +332,7 @@ class PutFileTypeCommand(RTOCommand):
 
         parser.add_argument("--json", help="Output raw JSON response", action="store_true", default=False)
 
-    def execute(self, client: Ratio, args):
+    def execute(self, client: Ratio, config: RTOConfig, args):
         """
         Execute the command.
 

--- a/rto/commands/files.py
+++ b/rto/commands/files.py
@@ -44,7 +44,7 @@ class ChangeFilePermissionsCommand(RTOCommand):
 
         parser.add_argument("file", help="The path to the file or directory", type=str)
 
-    def execute(self, client: Ratio, args):
+    def execute(self, client: Ratio, config: RTOConfig, args):
         """
         Execute the command.
 
@@ -52,8 +52,6 @@ class ChangeFilePermissionsCommand(RTOCommand):
         client -- The Ratio client
         args -- The command line arguments
         """
-        config = RTOConfig(config_dir=args.config_path)
-
         # Resolve the file path
         file_path = config.resolve_path(args.file)
 
@@ -113,7 +111,7 @@ class ChangeFileOwnerCommand(RTOCommand):
 
         parser.add_argument("file", help="The path to the file or directory", type=str)
 
-    def execute(self, client: Ratio, args):
+    def execute(self, client: Ratio, config: RTOConfig, args):
         """
         Execute the command.
 
@@ -121,8 +119,6 @@ class ChangeFileOwnerCommand(RTOCommand):
         client -- The Ratio client
         args -- The command line arguments
         """
-        config = RTOConfig(config_dir=args.config_path)
-
         # Resolve the file path
         file_path = config.resolve_path(args.file)
 
@@ -181,7 +177,7 @@ class ChangeFileGroupCommand(RTOCommand):
         parser.add_argument("group", help="The new group", type=str)
         parser.add_argument("file", help="The path to the file or directory", type=str)
 
-    def execute(self, client: Ratio, args):
+    def execute(self, client: Ratio, config: RTOConfig, args):
         """
         Execute the command.
 
@@ -189,8 +185,6 @@ class ChangeFileGroupCommand(RTOCommand):
         client -- The Ratio client
         args -- The command line arguments
         """
-        config = RTOConfig(config_dir=args.config_path)
-
         # Resolve the file path
         file_path = config.resolve_path(args.file)
 
@@ -332,7 +326,7 @@ class CreateDirectoryCommand(RTOCommand):
 
         parser.add_argument("directory", help="The full path to the directory to create", type=str)
 
-    def execute(self, client: Ratio, args):
+    def execute(self, client: Ratio, config: RTOConfig, args):
         """
         Execute the command.
 
@@ -340,8 +334,6 @@ class CreateDirectoryCommand(RTOCommand):
         client -- The Ratio client
         args -- The command line arguments
         """
-        config = RTOConfig(config_dir=args.config_path)
-
         # Resolve the directory path
         directory_path = config.resolve_path(args.directory)
 
@@ -457,7 +449,7 @@ class CreateFileCommand(RTOCommand):
 
         parser.add_argument("content", help="Content to write to the file (optional)", nargs="?")
 
-    def execute(self, client: Ratio, args):
+    def execute(self, client: Ratio, config: RTOConfig, args):
         """
         Execute the command.
 
@@ -465,8 +457,6 @@ class CreateFileCommand(RTOCommand):
         client -- The Ratio client
         args -- The command line arguments
         """
-        config = RTOConfig(config_dir=args.config_path)
-
         file_path = config.resolve_path(args.file)
 
         # Check if the file already exists
@@ -593,7 +583,7 @@ class DeleteFileCommand(RTOCommand):
 
         parser.add_argument("--json", help="Output raw JSON response", action="store_true", default=False)
 
-    def execute(self, client: Ratio, args):
+    def execute(self, client: Ratio, config: RTOConfig, args):
         """
         Execute the command.
 
@@ -601,8 +591,6 @@ class DeleteFileCommand(RTOCommand):
         client -- The Ratio client
         args -- The command line arguments
         """
-        config = RTOConfig(config_dir=args.config_path)
-
         # Resolve the file path
         file_path = config.resolve_path(args.file)
 
@@ -673,7 +661,7 @@ class DeleteFileVersionCommand(RTOCommand):
 
         parser.add_argument("--json", help="Output raw JSON response", action="store_true", default=False)
 
-    def execute(self, client: Ratio, args):
+    def execute(self, client: Ratio, config: RTOConfig, args):
         """
         Execute the command.
 
@@ -681,8 +669,6 @@ class DeleteFileVersionCommand(RTOCommand):
         client -- The Ratio client
         args -- The command line arguments
         """
-        config = RTOConfig(config_dir=args.config_path)
-
         # Resolve the file path
         file_path = config.resolve_path(args.file)
 
@@ -746,7 +732,7 @@ class DescribeFileCommand(RTOCommand):
 
         parser.add_argument("--json", help="Output raw JSON response", action="store_true", default=False)
 
-    def execute(self, client: Ratio, args):
+    def execute(self, client: Ratio, config: RTOConfig, args):
         """
         Execute the command.
 
@@ -754,8 +740,6 @@ class DescribeFileCommand(RTOCommand):
         client -- The Ratio client
         args -- The command line arguments
         """
-        config = RTOConfig(config_dir=args.config_path)
-
         # Resolve the file path
         file_path = config.resolve_path(args.file)
 
@@ -883,7 +867,7 @@ class DescribeFileVersionCommand(RTOCommand):
 
         parser.add_argument("--json", help="Output raw JSON response", action="store_true", default=False)
 
-    def execute(self, client: Ratio, args):
+    def execute(self, client: Ratio, config: RTOConfig, args):
         """
         Execute the command.
 
@@ -891,7 +875,6 @@ class DescribeFileVersionCommand(RTOCommand):
         client -- The Ratio client
         args -- The command line arguments
         """
-        config = RTOConfig(config_dir=args.config_path)
         # Resolve the file path
         file_path = config.resolve_path(args.file)
 
@@ -1011,7 +994,7 @@ class GetFileVersionCommand(RTOCommand):
 
         parser.add_argument("--quiet", "-q", help="Suppress informational messages", action="store_true", default=False)
 
-    def execute(self, client: Ratio, args):
+    def execute(self, client: Ratio, config: RTOConfig, args):
         """
         Execute the command.
 
@@ -1019,8 +1002,6 @@ class GetFileVersionCommand(RTOCommand):
         client -- The Ratio client
         args -- The command line arguments
         """
-        config = RTOConfig(config_dir=args.config_path)
-
         # Resolve the file path
         file_path = config.resolve_path(args.file)
 
@@ -1131,7 +1112,7 @@ class ListFileVersionsCommand(RTOCommand):
 
         parser.add_argument("--json", help="Output raw JSON response", action="store_true", default=False)
 
-    def execute(self, client: Ratio, args):
+    def execute(self, client: Ratio, config: RTOConfig, args):
         """
         Execute the command.
 
@@ -1139,8 +1120,6 @@ class ListFileVersionsCommand(RTOCommand):
         client -- The Ratio client
         args -- The command line arguments
         """
-        config = RTOConfig(config_dir=args.config_path)
-
         # Resolve the file path
         file_path = config.resolve_path(args.file)
 

--- a/rto/commands/initialize.py
+++ b/rto/commands/initialize.py
@@ -7,6 +7,7 @@ from ratio.client.client import Ratio
 from ratio.client.requests.auth import InitializeRequest
 
 from rto.commands.base import RTOCommand
+from rto.config import RTOConfig
 from rto.keys import generate_rsa_key_pair
 
 
@@ -25,7 +26,7 @@ class InitializeCommand(RTOCommand):
         """
         parser.add_argument("--public-key", help="Path to the public key file", type=str, required=False)
 
-    def execute(self, client: Ratio, args):
+    def execute(self, client: Ratio, config: RTOConfig, args):
         """
         Execute the command.
         """

--- a/rto/commands/navigation.py
+++ b/rto/commands/navigation.py
@@ -24,10 +24,8 @@ class ChangeDirectoryCommand(RTOCommand):
                            help="Directory to change to (use absolute path or relative to current working directory)",
                            nargs="?", default="/")  # Default to root if no directory specified
 
-    def execute(self, client: Ratio, args):
+    def execute(self, client: Ratio, config: RTOConfig, args):
         """Execute the command."""
-        config = RTOConfig(args.profile)
-
         current_dir = config.get_working_directory()
 
         # Remove trailing slash from current directory (unless it's root)
@@ -120,12 +118,10 @@ class ListFilesCommand(RTOCommand):
         parser.add_argument("directory", help="Directory to list (defaults to current working directory)", 
                             nargs="?", default=None, type=str)
 
-    def execute(self, client: Ratio, args):
+    def execute(self, client: Ratio, config: RTOConfig, args):
         """
         Execute the command.
         """
-        config = RTOConfig(config_dir=args.config_path)
-
         target_dir = config.resolve_path(path=args.directory)
 
         # Remove trailing slashes (except for root)
@@ -292,10 +288,8 @@ class PrintWorkingDirectoryCommand(RTOCommand):
         # No additional arguments needed
         pass
 
-    def execute(self, client: Ratio, args):
+    def execute(self, client: Ratio, config: RTOConfig, args):
         """Execute the command."""
-        config = RTOConfig(config_dir=args.config_path)
-
         working_dir = config.get_working_directory()
 
         print(working_dir)

--- a/rto/commands/process.py
+++ b/rto/commands/process.py
@@ -36,7 +36,7 @@ class DescribeProcessCommand(RTOCommand):
 
         parser.add_argument("--json", help="Output raw JSON response", action="store_true", default=False)
 
-    def execute(self, client: Ratio, args):
+    def execute(self, client: Ratio, config: RTOConfig, args):
         """
         Execute the command.
 
@@ -146,7 +146,7 @@ class ExecuteAgentCommand(RTOCommand):
 
         parser.add_argument("--wait", help="Wait for the agent execution to complete", action="store_true", default=False)
 
-    def execute(self, client: Ratio, args):
+    def execute(self, client: Ratio, config: RTOConfig, args):
         """
         Execute the command.
         
@@ -156,11 +156,8 @@ class ExecuteAgentCommand(RTOCommand):
         """
         agent_definition_path = args.agent_definition_path
 
-        if agent_definition_path:
-            config = RTOConfig(config_dir=args.config_path)
-
-            # Resolve the file path
-            agent_definition_path = config.resolve_path(args.agent_definition_path)
+        # Resolve the file path
+        agent_definition_path = config.resolve_path(args.agent_definition_path)
 
         # Create the request - passing the path directly to the API
         request = ExecuteAgentRequest(
@@ -272,7 +269,7 @@ class ListProcessesCommand(RTOCommand):
         parser.add_argument("--json", help="Output raw JSON response", action="store_true", default=False)
         parser.add_argument("--detailed", "-d", help="Show detailed information for each process", action="store_true", default=False)
 
-    def execute(self, client: Ratio, args):
+    def execute(self, client: Ratio, config: RTOConfig, args):
         """
         Execute the command.
         

--- a/rto/commands/schedule.py
+++ b/rto/commands/schedule.py
@@ -56,7 +56,7 @@ class CreateSubscriptionCommand(RTOCommand):
 
         parser.add_argument("--json", help="Output raw JSON response", action="store_true", default=False)
 
-    def execute(self, client: Ratio, args):
+    def execute(self, client: Ratio, config: RTOConfig, args):
         """
         Execute the command.
 
@@ -64,8 +64,6 @@ class CreateSubscriptionCommand(RTOCommand):
         client -- The Ratio client
         args -- The command line arguments
         """
-        config = RTOConfig(config_dir=args.config_path)
-
         # Resolve paths
         agent_definition_path = config.resolve_path(args.agent_definition)
 
@@ -172,7 +170,7 @@ class DeleteSubscriptionCommand(RTOCommand):
 
         parser.add_argument("--json", help="Output raw JSON response", action="store_true", default=False)
 
-    def execute(self, client: Ratio, args):
+    def execute(self, client: Ratio, config: RTOConfig, args):
         """
         Execute the command.
 
@@ -243,7 +241,7 @@ class DescribeSubscriptionCommand(RTOCommand):
 
         parser.add_argument("--json", help="Output raw JSON response", action="store_true", default=False)
 
-    def execute(self, client: Ratio, args):
+    def execute(self, client: Ratio, config: RTOConfig, args):
         """
         Execute the command.
 
@@ -361,7 +359,7 @@ class ListSubscriptionsCommand(RTOCommand):
         parser.add_argument("--detailed", "-d", help="Show detailed information for each subscription", 
                            action="store_true", default=False)
 
-    def execute(self, client: Ratio, args):
+    def execute(self, client: Ratio, config: RTOConfig, args):
         """
         Execute the command.
 

--- a/rto/commands/sync.py
+++ b/rto/commands/sync.py
@@ -15,6 +15,7 @@ from ratio.client.requests.storage import (
 )
 
 from rto.commands.base import RTOCommand, RTOErrorMessage
+from rto.config import RTOConfig
 
 
 class SyncCommand(RTOCommand):
@@ -70,7 +71,7 @@ class SyncCommand(RTOCommand):
 
         parser.add_argument("--encoding-map-file", help="Path to JSON file mapping file extensions to encoding types", type=str)
 
-    def execute(self, client: Ratio, args):
+    def execute(self, client: Ratio, config: RTOConfig, args):
         """
         Execute the command.
 

--- a/rto/shell.py
+++ b/rto/shell.py
@@ -219,7 +219,7 @@ class RTO:
 
                     cmd = cmd_klass()
 
-                    cmd.execute(ratio, args)
+                    cmd.execute(ratio, self._config, args)
 
                     return
 
@@ -274,7 +274,7 @@ class RTO:
 
         cmd = cmd_klass()
 
-        cmd.execute(ratio, args)
+        cmd.execute(ratio, self._config, args)
 
     def execute(self):
         """

--- a/utils/ratio-shell
+++ b/utils/ratio-shell
@@ -3,7 +3,7 @@
 # ratio-shell - Interactive shell for Ratio CLI
 
 # Configuration
-RATIO_HOME="$HOME/.ratio"
+RATIO_HOME="$HOME/.rto"
 RATIO_SHELL_HOME="$RATIO_HOME/shell"
 RATIO_BIN="$RATIO_SHELL_HOME/bin"
 RATIO_HISTORY="$RATIO_SHELL_HOME/history"
@@ -11,7 +11,9 @@ RATIO_HISTORY="$RATIO_SHELL_HOME/history"
 # Create directories if they don't exist
 mkdir -p "$RATIO_SHELL_HOME"
 mkdir -p "$RATIO_BIN"
-mkdir -p "$RATIO_HISTORY"
+
+# Create history file if it doesn't exist
+touch "$RATIO_HISTORY"
 
 # Add bin directory to PATH
 export PATH="$RATIO_BIN:$PATH"
@@ -179,6 +181,12 @@ initialize_working_directory() {
     fi
 }
 
+cleanup() {
+    echo -e "\n${CYAN}Saving history and exiting Ratio Shell${RESET}"
+    history -w
+    exit 0
+}
+
 # Display help information for the shell
 show_help() {
     echo -e "${BOLD}${CYAN}Ratio Shell Help:${RESET}"
@@ -198,9 +206,13 @@ show_help() {
 }
 
 # Set up command line editing and history
-export HISTFILE="$RATIO_HISTORY/history"
+export HISTFILE=$RATIO_HISTORY
 export HISTSIZE=1000
 export HISTFILESIZE=2000
+
+# Read past history
+history -r
+
 shopt -s histappend
 
 # Welcome and setup with colors
@@ -221,6 +233,9 @@ initialize_working_directory
 # Update working directory and deployment ID
 RATIO_PWD=$(run_ratio print-working-directory 2>/dev/null || echo "/")
 
+
+# Cleanup on exit
+trap cleanup SIGINT
 
 # Main shell loop
 while true; do
@@ -246,8 +261,7 @@ while true; do
     # Process commands with explicit handling for each case
     case "$command" in
         "exit"|"quit")
-            echo -e "${CYAN}Exiting Ratio Shell${RESET}"
-            exit 0
+            cleanup
             ;;
         "help")
             show_help
@@ -259,9 +273,13 @@ while true; do
             # Handle variable references
             eval "echo $command"
             ;;
+        "history"|"echo")
+            "${command}" "${args[@]}"
+            ;;
         "sys")
             # Expand ~ in arguments for system commands
             expanded_args=()
+
             for arg in "${args[@]}"; do
                 # Replace ~ with $HOME
                 expanded_arg="${arg/#\~/$HOME}"
@@ -274,15 +292,18 @@ while true; do
 
             LAST_STATUS=$?
             ;;
+        "rto")
+            run_ratio "${args[@]}"
+            ;;
         *)
-            # Check for custom scripts first
+            # Check for custom scripts
             if is_bin_script "$command"; then
                 "$RATIO_BIN/$command" "${args[@]}"
+
                 LAST_STATUS=$?
 
-            else 
+            else
                 run_ratio "$command" "${args[@]}"
-
             fi
             ;;
     esac


### PR DESCRIPTION
- Pass the config object to RTO commands to ensure using correct config
- Add support for graceful cleanup of ratio-shell
- Enable echo and history as direct pass through commands