### PR TITLE
Improve Bedrock Attachment Support

### DIFF
--- a/_fs/agents/core/bedrock_anthropic.agent
+++ b/_fs/agents/core/bedrock_anthropic.agent
@@ -36,29 +36,17 @@
       "default_value": 0.9
     },
     {
-      "name": "attachment_path",
-      "type_name": "string",
-      "description": "Path to an optional attachment file to include with the prompt",
-      "required": false,
-      "required_conditions": [
-        {
-          "operator": "exists",
-          "param": "attachment_type_name"
-        }
-      ]
+      "name": "attachment_paths",
+      "type_name": "list",
+      "description": "Paths to an optional attachment image files to include with the prompt",
+      "required": false
     },
     {
-      "name": "attachment_type_name",
+      "name": "attachment_content_type",
       "type_name": "string",
       "description": "type_name of the attachment file",
       "required": false,
-      "enum": ["image/jpeg", "image/png", "image/gif", "application/pdf"],
-      "required_conditions": [
-        {
-          "operator": "exists",
-          "param": "attachment_path"
-        }
-      ]
+      "enum": ["image/jpeg", "image/png", "image/gif", "image/webp"]
     },
     {
       "name": "result_file_path",

--- a/ratio/agents/bedrock_anthropic/runtime/run.py
+++ b/ratio/agents/bedrock_anthropic/runtime/run.py
@@ -4,7 +4,6 @@ Amazon Bedrock Anthropic Agent
 This agent invokes Anthropic Claude models through Amazon Bedrock. It processes text prompts 
 with optional attachments (images or PDFs) and saves responses to a file.
 """
-import base64
 import boto3
 import json
 import logging
@@ -25,9 +24,17 @@ from ratio.agents.agent_lib import RatioSystem
 _FN_NAME = "ratio.agents.bedrock.anthropic"
 
 
-class AttachmentError(Exception):
-    """Exception raised for errors related to attachment handling."""
+class ResponseSaveError(Exception):
+    """Exception raised for errors related to saving responses."""
     pass
+
+
+SUPPORTED_IMAGE_TYPES = {
+    "image/gif",
+    "image/jpeg",
+    "image/png", 
+    "image/webp",
+}
 
 
 @fn_event_response(exception_reporter=ExceptionReporter(), function_name=_FN_NAME, logger=Logger(_FN_NAME))
@@ -54,15 +61,15 @@ def handler(event: Dict, context: Dict):
 
         top_p = system.arguments.get("top_p", default_return=0.9)
 
-        attachment_path = system.arguments.get("attachment_path", default_return=None)
+        attachment_paths = system.arguments.get("attachment_paths", default_return=[])
 
-        attachment_type = system.arguments.get("attachment_type", default_return=None)
+        attachment_type = system.arguments.get("attachment_content_type")
 
-        result_file_path = system.arguments.get("result_file_path", default_return=None)
+        result_file_path = system.arguments.get("result_file_path")
 
         # Create Bedrock Runtime client
         bedrock_runtime = boto3.client("bedrock-runtime")
-        
+
         # Prepare request body
         request_body = {
             "anthropic_version": "bedrock-2023-05-31",
@@ -72,40 +79,67 @@ def handler(event: Dict, context: Dict):
         }
 
         # Handle different formats for Claude models
-        if attachment_path and attachment_type:
-            # Get the attachment data
-            file_response = system.get_file_version(attachment_path)
+        if attachment_paths:
+            # Validate attachment count (Bedrock limit is 20 images)
+            if len(attachment_paths) > 20:
+                logging.debug(f"Too many attachments: {len(attachment_paths)} (limit is 20)")
+                system.failure(failure_message=f"Too many attachments: {len(attachment_paths)}. Maximum allowed is 20.")
+                return
 
-            file_data = file_response.get("data")
+            content_blocks = []
 
-            if not file_data:
-                raise AttachmentError(f"Failed to get attachment data from {attachment_path}")
-                
-            # Handle base64 encoded data if needed
-            if isinstance(file_data, str):
-                attachment_data = file_data
+            # Process each attachment
+            for i, attachment_path in enumerate(attachment_paths):
+                try:
+                    logging.debug(f"Processing attachment {i+1}/{len(attachment_paths)}: {attachment_path}")
 
-            else:
-                attachment_data = base64.b64encode(file_data).decode('utf-8')
+                    # Use the helper method to get binary file as base64
+                    binary_file = system.get_binary_file_version(attachment_path)
+
+                    attachment_data = binary_file["data"]
+
+                    if attachment_type:
+                        content_type = attachment_type
+
+                    else:
+                        content_type = binary_file["content_type"]
+
+                    # Validate supported image types
+                    if content_type not in SUPPORTED_IMAGE_TYPES:
+                        logging.debug(f"Attachment content type {content_type} is not supported for {attachment_path}")
+
+                        system.failure(failure_message=f"Attachment content type {content_type} is not supported for {attachment_path}")
+
+                        return
+
+                    # Add image to content blocks
+                    content_blocks.append({
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": content_type,
+                            "data": attachment_data
+                        }
+                    })
+
+                    logging.debug(f"Loaded {binary_file['original_format']} file as base64, content type: {content_type}")
+
+                except Exception as attach_error:
+                    logging.debug(f"Failed to load attachment {attachment_path}: {attach_error}")
+                    system.failure(failure_message=f"Failed to load attachment {attachment_path}: {attach_error}")
+                    return
+
+            # Add text prompt at the end
+            content_blocks.append({
+                "type": "text",
+                "text": prompt
+            })
 
             # Format with multimodal content
             request_body["messages"] = [
                 {
                     "role": "user",
-                    "content": [
-                        {
-                            "type": "image",
-                            "source": {
-                                "type": "base64",
-                                "media_type": attachment_type,
-                                "data": attachment_data
-                            }
-                        },
-                        {
-                            "type": "text",
-                            "text": prompt
-                        }
-                    ]
+                    "content": content_blocks
                 }
             ]
 
@@ -116,7 +150,7 @@ def handler(event: Dict, context: Dict):
                     "role": "user",
                     "content": [
                         {
-                            "type": "text",
+                            "type": "text", 
                             "text": prompt
                         }
                     ]
@@ -152,16 +186,20 @@ def handler(event: Dict, context: Dict):
             result_file_path = os.path.join(system.working_directory, f"response_{uuid.uuid4()}.txt")
 
         # Save response to file
-        system.put_file(
-            file_path=result_file_path,
-            file_type="ratio::file",
-            data=model_response,
-            metadata={
-                "model_id": model_id,
-                "input_tokens": input_tokens,
-                "output_tokens": output_tokens
-            }
-        )
+        try:
+            system.put_file(
+                file_path=result_file_path,
+                file_type="ratio::file",
+                data=model_response,
+                metadata={
+                    "model_id": model_id,
+                    "input_tokens": input_tokens,
+                    "output_tokens": output_tokens
+                }
+            )
+
+        except Exception as put_file_error:
+            raise ResponseSaveError(f"Failed to save response to {result_file_path}: {put_file_error}")
 
         # Return success with metrics
         system.success(

--- a/ratio/core/services/storage_manager/runtime/file_types.py
+++ b/ratio/core/services/storage_manager/runtime/file_types.py
@@ -120,9 +120,7 @@ class FileTypesAPI(ChildAPI):
 
         return self.respond(
             status_code=200,
-            body={
-                "file_type": f_type.to_dict(json_compatible=True),
-            },
+            body=f_type.to_dict(json_compatible=True),
         )
 
     def list_file_types(self, request_body: ObjectBody, request_context: Dict):

--- a/ratio/core/services/storage_manager/stack.py
+++ b/ratio/core/services/storage_manager/stack.py
@@ -166,6 +166,46 @@ class StorageManagerStack(Stack):
             content_type="application/octet-stream"
         )
 
+        RegisteredFileType(
+            scope=self,
+            type_name="ratio::text",
+            description="FS Text File",
+            is_directory_type=False,
+            content_type="text/plain"
+        )
+
+        RegisteredFileType(
+            scope=self,
+            type_name="ratio::gif",
+            description="FS GIF Image File",
+            is_directory_type=False,
+            content_type="image/gif"
+        )
+
+        RegisteredFileType(
+            scope=self,
+            type_name="ratio::jpeg",
+            description="FS JPEG Image File",
+            is_directory_type=False,
+            content_type="image/jpeg"
+        )
+
+        RegisteredFileType(
+            scope=self,
+            type_name="ratio::png",
+            description="FS PNG Image File",
+            is_directory_type=False,
+            content_type="image/png"
+        )
+
+        RegisteredFileType(
+            scope=self,
+            type_name="ratio::webp",
+            description="FS WEBP Image File",
+            is_directory_type=False,
+            content_type="image/webp"
+        )
+
         RegisteredFile(
             scope=self,
             file_path="/home",

--- a/rto/commands/file_types.py
+++ b/rto/commands/file_types.py
@@ -145,21 +145,18 @@ class DescribeFileTypeCommand(RTOCommand):
         Keyword arguments:
         type_data -- The file type data to format
         """
-        print(f"File Type: {type_data.get('file_type', 'Unknown')}")
+        print(f"File Type: {type_data["type_name"]}")
 
-        print(f"Description: {type_data.get('description', 'None')}")
+        print(f"Description: {type_data.get("description", "None")}")
 
-        if 'is_container_type' in type_data:
-            print(f"Is Container Type: {type_data.get('is_container_type')}")
+        if "is_container_type" in type_data:
+            print(f"Is Container Type: {type_data.get("is_container_type")}")
 
-        if 'content_search_instructions_path' in type_data:
-            print(f"Content Search Instructions: {type_data.get('content_search_instructions_path')}")
-
-        if 'name_restrictions' in type_data:
-            print(f"Name Restrictions: {type_data.get('name_restrictions')}")
+        if "name_restrictions" in type_data:
+            print(f"Name Restrictions: {type_data.get("name_restrictions")}")
 
         # Print metadata if present
-        metadata = type_data.get('metadata', {})
+        metadata = type_data.get("metadata", {})
 
         if metadata:
             print("\nMetadata:")
@@ -171,8 +168,8 @@ class DescribeFileTypeCommand(RTOCommand):
         print("\nAdditional Properties:")
 
         for key, value in type_data.items():
-            if key not in ['file_type', 'description', 'is_container_type', 
-                          'content_search_instructions_path', 'name_restrictions', 'metadata']:
+            if key not in ["file_type", "description", "is_container_type", 
+                           "name_restrictions", "metadata"]:
                 print(f"  {key}: {value}")
 
 
@@ -229,10 +226,11 @@ class ListFileTypesCommand(RTOCommand):
             # Apply filter if specified
             if args.filter:
                 filter_term = args.filter.lower()
-                file_types_dicts = [ft for ft in file_types_dicts if filter_term in ft['type_name'].lower()]
+
+                file_types_dicts = [ft for ft in file_types_dicts if filter_term in ft["type_name"].lower()]
 
             # Extract just the names for simple view
-            file_type_names = [ft['type_name'] for ft in file_types_dicts]
+            file_type_names = [ft["type_name"] for ft in file_types_dicts]
 
             if args.json:
                 # Output raw JSON
@@ -248,8 +246,7 @@ class ListFileTypesCommand(RTOCommand):
                 self._show_detailed_file_types(file_types_dicts)
 
             else:
-                # Simple list output with formatting
-                self._show_simple_file_types(file_type_names)
+                print("\n".join(file_type_names))
 
         except json.JSONDecodeError:
             raise RTOErrorMessage(f"Could not parse response as JSON: {resp.response_body}")
@@ -276,30 +273,31 @@ class ListFileTypesCommand(RTOCommand):
             if i > 0:
                 print("\n" + "-" * 40)
 
-            print(f"File Type: {type_data.get('type_name', 'Unknown')}")
+            print(f"File Type: {type_data.get("type_name", "Unknown")}")
 
             # Display key information
-            print(f"  Description: {type_data.get('description', 'None')}")
+            print(f"  Description: {type_data.get("description", "None")}")
 
-            if 'is_directory_type' in type_data:
-                print(f"  Is Directory Type: {type_data.get('is_directory_type')}")
+            if "is_directory_type" in type_data:
+                print(f"  Is Directory Type: {type_data.get("is_directory_type")}")
 
-            if 'content_type' in type_data:
-                content_type = type_data.get('content_type')
+            if "content_type" in type_data:
+                content_type = type_data.get("content_type")
+
                 if content_type:
                     print(f"  Content Type: {content_type}")
 
-            if 'name_restrictions' in type_data:
-                print(f"  Name Restrictions: {type_data.get('name_restrictions')}")
+            if "name_restrictions" in type_data:
+                print(f"  Name Restrictions: {type_data.get("name_restrictions")}")
 
-            if 'files_cannot_be_deleted' in type_data:
-                print(f"  Files Cannot Be Deleted: {type_data.get('files_cannot_be_deleted')}")
+            if "files_cannot_be_deleted" in type_data:
+                print(f"  Files Cannot Be Deleted: {type_data.get("files_cannot_be_deleted")}")
 
-            if 'added_on' in type_data:
-                print(f"  Added On: {type_data.get('added_on')}")
+            if "added_on" in type_data:
+                print(f"  Added On: {type_data.get("added_on")}")
 
-            if 'last_updated_on' in type_data:
-                print(f"  Last Updated On: {type_data.get('last_updated_on')}")
+            if "last_updated_on" in type_data:
+                print(f"  Last Updated On: {type_data.get("last_updated_on")}")
 
         print(f"\nTotal: {len(file_types_dicts)} file types")
 


### PR DESCRIPTION
- Normalize file type description output to just response and add additional default types for images and basic text
- Add support for binary syncing
- Add additional file types
- Fix Bedrock Anthropic agent attachments support
- Fix bedrock agent arguments
- Add back file_type normalization and file type definitions
- Add default ecodings and type map